### PR TITLE
Kill queries if migrations take too long

### DIFF
--- a/src/__tests__/migrate.js
+++ b/src/__tests__/migrate.js
@@ -391,6 +391,27 @@ test("rollback", (t) => {
     })
 })
 
+test("timeout failure", t => {
+  const databaseName = "migration-test-timeout"
+  const dbConfig = {
+    database: databaseName,
+    user: "postgres",
+    password: PASSWORD,
+    host: "localhost",
+    port,
+  }
+
+  const promise = createDb(databaseName, dbConfig)
+    .then(() => migrate(dbConfig, "src/__tests__/timeout", {
+      migrationTimeout: 500,
+    }))
+
+  return t.throwsAsync(() => promise)
+    .then((err) => {
+      t.regex(err.message, /canceling statement due to user request/)
+    })
+})
+
 test.after.always(() => {
   execSync(`docker rm -f ${CONTAINER_NAME}`)
 })

--- a/src/__tests__/timeout/1_migration.sql
+++ b/src/__tests__/timeout/1_migration.sql
@@ -1,0 +1,1 @@
+SELECT pg_sleep(1);


### PR DESCRIPTION
This PR will ensure that all migrations happen within a certain timeframe. The default time is specified as 60,000ms (1 minute), but this can be overridden when calling the `migrate` function by setting the `migrationTimeout` configuration value.

If the timeout is reached, it will kill the query and throw an error.

Test added to verify it works with a `SELECT pg_sleep(1)` migration script.
