### PR TITLE
Add locking mechanism to prevent multiple executions

### DIFF
--- a/src/__tests__/lock/1_first.sql
+++ b/src/__tests__/lock/1_first.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id integer
+);

--- a/src/lock.js
+++ b/src/lock.js
@@ -1,0 +1,54 @@
+const SQL = require("sql-template-strings")
+const crypto = require("crypto")
+
+const createLockTableIfExists = client => {
+  return client.query(
+    SQL`
+CREATE TABLE IF NOT EXISTS migration_locks (
+  hash varchar(40) NOT NULL PRIMARY KEY
+);
+`,
+  )
+}
+
+const generateMigrationHash = migrations => {
+  const hash = crypto.createHash("sha1")
+  migrations.forEach(migration => {
+    hash.update(migration.sql)
+  })
+
+  return hash.digest("hex")
+}
+
+const verifyLockDoesNotExist = async (client, hash) => {
+  const result = await client.query(
+    SQL`
+SELECT hash FROM migration_locks
+  WHERE hash = ${hash}
+    `,
+  )
+
+  if (result.rowCount) {
+    throw new Error(`Current migration is locked: ${hash}`)
+  }
+}
+
+const removeLock = (client, hash) => {
+  return client.query(
+    SQL`DELETE FROM migration_locks WHERE hash = ${hash};`,
+  )
+}
+
+const insertLock = (client, hash) => {
+  return client.query(
+    SQL`INSERT INTO migration_locks (hash) VALUES (${hash})`,
+  )
+}
+
+module.exports = {
+  createLockTableIfExists,
+  generateMigrationHash,
+  verifyLockDoesNotExist,
+  removeLock,
+  insertLock,
+}


### PR DESCRIPTION
This PR:
- adds a `migration_locks` table to the database if it doesn't exist already
- the hash for all migrations to be run is calculated
- if the hash exists in the lock table, throw an error and don't continue executing
- else add the hash to the lock table
- when the migration script exits, the lock is removed