### PR TITLE
MON-429  allow non public schemas

### DIFF
--- a/src/__tests__/migrate.js
+++ b/src/__tests__/migrate.js
@@ -9,7 +9,7 @@ const startPostgres = require("./_start-postgres")
 
 const createDb = require("../create")
 const migrate = require("../migrate")
-const {createLockTableIfExists, insertLock} = require("../lock")
+const {createLockTableIfNotExists, insertLock} = require("../lock")
 const crypto = require("crypto")
 
 const CONTAINER_NAME = "pg-migrations-test-migrate"
@@ -448,11 +448,12 @@ test.after.always(() => {
 function insertMigrationLock(dbConfig, hash) {
   const client = bluebird.promisifyAll(new pg.Client(dbConfig))
   return client.connect()
-    .then(() => createLockTableIfExists(client))
+    .then(() => createLockTableIfNotExists(client))
     .then(() => insertLock(client, hash))
     .finally(() => client.end())
 }
 
+// Different to the doesTableExist in migrate.js
 function doesTableExist(dbConfig, tableName) {
   const client = bluebird.promisifyAll(new pg.Client(dbConfig))
   return client.connect()

--- a/src/migrations/0_create-migrations-table.sql
+++ b/src/migrations/0_create-migrations-table.sql
@@ -1,6 +1,17 @@
-CREATE TABLE IF NOT EXISTS migrations (
-  id integer PRIMARY KEY,
-  name varchar(100) UNIQUE NOT NULL,
-  hash varchar(40) NOT NULL, -- sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
-  executed_at timestamp DEFAULT current_timestamp
-);
+DO $$
+DECLARE
+  schema_name text := current_setting('app.schema', true);
+BEGIN
+  IF schema_name IS NULL THEN
+    schema_name := 'public';
+  END IF;
+
+  -- hash here is sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
+  EXECUTE format('CREATE TABLE IF NOT EXISTS %I.migrations (
+    id integer PRIMARY KEY,
+    name varchar(100) UNIQUE NOT NULL,
+    hash varchar(40) NOT NULL,
+    executed_at timestamp DEFAULT current_timestamp
+  )', schema_name);
+END
+$$;

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,27 @@
+const createSchemaIfNotExists = (client, schema) => {
+  if (!schema || schema === "public") {
+    return Promise.resolve()
+  }
+  const plpgsql = `
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = '${schema}') THEN
+    EXECUTE format('CREATE SCHEMA %I', '${schema}');
+  END IF;
+END
+$$;
+`
+  return client.query(plpgsql)
+}
+
+const setSchema = (client, log, schema) => {
+  return client.query(`SET app.schema = '${schema}'`)
+    .then(() => client.query(`SET search_path TO '${schema}'`))
+    .then(() => log(`Set schema in app.schema and search_path to: ${schema}`))
+
+}
+
+module.exports = {
+  createSchemaIfNotExists,
+  setSchema,
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+const quoteIdent = (str) => {
+  return `"${str.replace(/"/g, "\"\"")}"`
+}
+
+module.exports = {
+  quoteIdent,
+}


### PR DESCRIPTION
- Move pg from `devDependencies` to `dependencies`
- Support ` non-public schema. User can pass one in when calling `migrate` as part of the 3rd argument (config), and then if it's set the schema will be created and then used for the migrations. It is NOT necessary to specify the schema manually in the migration files as the `SET search_path TO...` sets this up for the remainder of the migration call.

**TODO once this is merged:**
- Create new release (2.5.0-alpha or 3.0.0-alpha)
- Update data-enrichment-engine to use the new version in this PR: https://github.com/moneyhub/data-enrichment-engine/pull/178